### PR TITLE
Remove proclaim sinon import from test boilerplate.

### DIFF
--- a/templates/test-js.js
+++ b/templates/test-js.js
@@ -5,8 +5,7 @@ module.exports = answers => {
 	const className = titleCase(withoutPrefix(name));
 
 	return `/* eslint-env mocha */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* global proclaim sinon */
 import * as fixtures from './helpers/fixtures';
 import ${className} from '../../main';
 


### PR DESCRIPTION
These are `obt test` globals and cannot be resolved through an import.