### PR TITLE
Add remark lint config and the missing linting tools themselves for editor plugins to use

### DIFF
--- a/templates/package-json.js
+++ b/templates/package-json.js
@@ -3,9 +3,13 @@ module.exports = (answers) => {
 	"private": true,
 	"name": "${answers.name}",
 	"devDependencies": {
+		"eslint": "^7.1.0",
 		"eslint-config-origami-component": "^2.0.1",
 		"origami-ci-tools": "^2.0.0",
+		"remark": "^12.0.0",
+		"remark-lint": "^7.0.0",
 		"remark-preset-lint-origami-component": "^1.1.1",
+		"stylelint": "^13.5.0",
 		"stylelint-config-origami-component": "^1.0.2"
 	}
 }`;

--- a/templates/package-json.js
+++ b/templates/package-json.js
@@ -5,6 +5,7 @@ module.exports = (answers) => {
 	"devDependencies": {
 		"eslint-config-origami-component": "^2.0.1",
 		"origami-ci-tools": "^2.0.0",
+		"remark-preset-lint-origami-component": "^1.1.1",
 		"stylelint-config-origami-component": "^1.0.2"
 	}
 }`;


### PR DESCRIPTION
Without the linting tools installed, editor plugins complain that the tools are missing.

I came across this issue when following the create an origami component tutorial