### PR TITLE
Remove underscore and extension from the brand import

### DIFF
--- a/templates/main-scss.js
+++ b/templates/main-scss.js
@@ -4,7 +4,7 @@ module.exports = answers => {
 	const name = answers.name;
 
 	return `@import 'src/scss/variables';
-${answers.brands ? `@import 'src/scss/_brand.scss';` : ''}
+${answers.brands ? `@import 'src/scss/brand';` : ''}
 
 /// Output all ${camelCase(name)} features
 /// @param {Map} $opts [()] - A map of options to configure the output


### PR DESCRIPTION
Our create a new origami component tutorial mentions they are not needed, we should keep our import style consistent with what the tutorial is explaining