### PR TITLE
Drop "module" type for "component" for spec v2 components

### DIFF
--- a/templates/origami-manifest.js
+++ b/templates/origami-manifest.js
@@ -1,6 +1,6 @@
 const details = answers => {
 	return `{
-	"origamiType": "module",
+	"origamiType": "component",
 	"origamiCategory": "${answers.category}",
 	"origamiVersion": "2.0",
 	"brands": ${JSON.stringify(answers.brands)},


### PR DESCRIPTION
Conversation: https://github.com/Financial-Times/origami-website/pull/273#discussion_r617396987