### PR TITLE
run npm-test workflow on all branches and pull-requests

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -2,9 +2,7 @@ name: npm test
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
Currently, if a pull-request is being made to a branch other than `master`, then the test workflow does not run.

This pull-requests changes it so that all pull-requests and branches have the test workflow run against them