### PR TITLE
Remove links and references to the now deprecated Origami spec.

### DIFF
--- a/src/prompts/questions.js
+++ b/src/prompts/questions.js
@@ -5,7 +5,7 @@ module.exports = {
 		message: "component name (required)",
 		validate: value => {
 			if (!value) {
-				return "please enter a name for your component\nhttps://origami.ft.com/spec/v1/components/#naming-conventions"
+				return "please enter a name for your component\nhttps://origami.ft.com/docs/components/code/#naming-conventions"
 			}
 			return true
 		}
@@ -35,7 +35,7 @@ module.exports = {
 		message: "description (required)",
 		validate: value => {
 			if (!value) {
-				return "please enter a description for your component\nhttps://origami.ft.com/spec/v1/manifest/#description"
+				return "please enter a description for your component\nhttps://origami.ft.com/docs/manifests/origami-json/#description"
 			}
 			return true
 		}
@@ -76,7 +76,7 @@ module.exports = {
 	status: {
 		name: "status",
 		type: "list",
-		message: "support status (https://origami.ft.com/spec/v1/manifest/#supportstatus)",
+		message: "support status (https://origami.ft.com/docs/manifests/origami-json/#supportstatus)",
 		default: "experimental",
 		choices: [
 			"active",
@@ -87,7 +87,7 @@ module.exports = {
 	brands: {
 		name: "brands",
 		type: "checkbox",
-		message: "supported brands (https://origami.ft.com/docs/components/branding/)",
+		message: "supported brands (https://origami.ft.com/docs/components/customisation/#brands)",
 		default: ["master"],
 		choices: [
 			"master",

--- a/templates/readme.js
+++ b/templates/readme.js
@@ -23,7 +23,7 @@ _Instructions for the component. We've broken this down by Markup, JavaScript, S
 
 ## Usage
 
-Check out [how to include Origami components in your project](https://origami.ft.com/docs/components/#including-origami-components-in-your-project) to get started with \`${name}\`.
+Check out [how to include Origami components in your project](https://origami.ft.com/docs/components/#including-components-in-your-project) to get started with \`${name}\`.
 
 ## Markup
 
@@ -58,7 +58,7 @@ _JavaScript documentation. Including how to initialise the component, available 
 _For complex components it may be helpful to document apis with JSDoc and link to the components JSDocs in the Origami Registry._
 _Remember to start your codeblocks with three backticks and "js" so your js is syntax highlighted correctly._
 
-JavaScript is initialised automatically for [Origami Build Service](https://www.ft.com/__origami/service/build/v2/) users. If your project is using a manual build process, [initialise  \`${name}\` manually](https://origami.ft.com/docs/components/initialising/).
+JavaScript is initialised automatically for [Origami Build Service](https://www.ft.com/__origami/service/build/v2/) users. If your project is using a manual build process, [initialise  \`${name}\` manually](https://origami.ft.com/docs/tutorials/manual-build/).
 
 For example call the \`init\` method to initialise all \`${name}\` instances in the document:
 
@@ -74,8 +74,6 @@ import ${camelCase(name)} from '${name}';
 const ${camelCase(name)}Element = document.getElementById('#my-${name}-element');
 ${camelCase(name)}.init(${camelCase(name)}Element);
 \`\`\`
-
-[Learn more about Origami component initialisation](https://origami.ft.com/docs/components/initialising/).
 `: ``}
 
 ## Troubleshooting


### PR DESCRIPTION
Links to the Origami website 404 currently. Depends on:
Financial-Times/origami-website#361